### PR TITLE
fix(concurrency): synchronize calculateRewards() logic

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -36,16 +36,18 @@ public class RewardsService {
 	public void setDefaultProximityBuffer() {
 		proximityBuffer = defaultProximityBuffer;
 	}
-	
+
 	public void calculateRewards(User user) {
-		List<VisitedLocation> userLocations = new CopyOnWriteArrayList<>(user.getVisitedLocations());
-		List<Attraction> attractions = gpsUtil.getAttractions();
-		
-		for(VisitedLocation visitedLocation : userLocations) {
-			for(Attraction attraction : attractions) {
-				if(user.getUserRewards().stream().noneMatch (r -> r.attraction.attractionName.equals(attraction.attractionName))) {
-					if(nearAttraction(visitedLocation, attraction)) {
-						user.addUserReward(new UserReward(visitedLocation, attraction, getRewardPoints(attraction, user)));
+		synchronized (user) {
+			List<VisitedLocation> userLocations = new CopyOnWriteArrayList<>(user.getVisitedLocations());
+			List<Attraction> attractions = gpsUtil.getAttractions();
+
+			for (VisitedLocation visitedLocation : userLocations) {
+				for (Attraction attraction : attractions) {
+					if (user.getUserRewards().stream().noneMatch(r -> r.attraction.attractionName.equals(attraction.attractionName))) {
+						if (nearAttraction(visitedLocation, attraction)) {
+							user.addUserReward(new UserReward(visitedLocation, attraction, getRewardPoints(attraction, user)));
+						}
 					}
 				}
 			}

--- a/TourGuide/src/test/java/com/openclassrooms/tourguide/TestRewardsService.java
+++ b/TourGuide/src/test/java/com/openclassrooms/tourguide/TestRewardsService.java
@@ -47,7 +47,6 @@ public class TestRewardsService {
 		assertTrue(rewardsService.isWithinAttractionProximity(attraction, attraction));
 	}
 
-	@Disabled // Needs fixed - AssertionFailedError
 	@Test
 	public void nearAllAttractions() {
 		GpsUtil gpsUtil = new GpsUtil();
@@ -63,5 +62,4 @@ public class TestRewardsService {
 
 		assertEquals(gpsUtil.getAttractions().size(), userRewards.size());
 	}
-
 }


### PR DESCRIPTION
# Correctif des doublons des récompenses

## Description
Cette PR résout un problème de duplication de récompenses lorsque plusieurs threads appellent simultanément la méthode `calculateRewards(User user)` pour un même utilisateur.

---

## Principales modifications
### RewardsService
Dans la méthode `calculateRewards()`, ajout d’un bloc `synchronized(user)` autour de toute la logique de calcul des récompenses.

Cela garantit que tout l'ensemble des opérations de lecture, vérification (`noneMatch`) et ajout (`addUserReward`) est exécuté de manière atomique pour un utilisateur donné. Ainsi, on évite que les deux threads (le thread main + le thread de Tracker) ajoutent une récompense pour la même attraction au même utilisateur, comme cela se produisait en l’absence de synchronisation (condition de course).

### TestRewardsService
Suppression de l’annotation `@Disabled` sur le test `nearAllAttractions()`, qui est désormais fonctionnel.

---

Les tests passent et le comportement est conforme à ce qui est attendu.

<img width="1396" height="129" alt="nearAllAttraction-test-OK" src="https://github.com/user-attachments/assets/2f6127a0-39a1-444a-8597-5310fe507a3a" />

