### PR TITLE
Feat/nearby attractions

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/TourGuideController.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/TourGuideController.java
@@ -2,6 +2,7 @@ package com.openclassrooms.tourguide;
 
 import java.util.List;
 
+import com.openclassrooms.tourguide.dto.NearbyAttractionDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,20 +32,29 @@ public class TourGuideController {
     public VisitedLocation getLocation(@RequestParam String userName) {
     	return tourGuideService.getUserLocation(getUser(userName));
     }
-    
-    //  TODO: Change this method to no longer return a List of Attractions.
- 	//  Instead: Get the closest five tourist attractions to the user - no matter how far away they are.
- 	//  Return a new JSON object that contains:
-    	// Name of Tourist attraction, 
-        // Tourist attractions lat/long, 
-        // The user's location lat/long, 
-        // The distance in miles between the user's location and each of the attractions.
-        // The reward points for visiting each Attraction.
-        //    Note: Attraction reward points can be gathered from RewardsCentral
+
+    /**
+     * Retrieves the five closest tourist attractions to the specified user.
+     * <p>
+     * The returned list contains detailed information for each attraction, including:
+     * <ul>
+     *   <li>The attraction's name,</li>
+     *   <li>The attraction's latitude and longitude,</li>
+     *   <li>The user's current latitude and longitude,</li>
+     *   <li>The distance in miles between the user and the attraction,</li>
+     *   <li>The reward points for visiting the attraction.</li>
+     * </ul>
+     *
+     * @param userName the name of the current user
+     * @return a list of {@link NearbyAttractionDto}
+     */
     @RequestMapping("/getNearbyAttractions") 
-    public List<Attraction> getNearbyAttractions(@RequestParam String userName) {
-    	VisitedLocation visitedLocation = tourGuideService.getUserLocation(getUser(userName));
-    	return tourGuideService.getNearByAttractions(visitedLocation);
+    public List<NearbyAttractionDto> getNearbyAttractions(@RequestParam String userName) {
+        User user = getUser(userName);
+        VisitedLocation visitedLocation = tourGuideService.getUserLocation(user);
+        List<Attraction> attractions = tourGuideService.getNearByAttractions(visitedLocation);
+
+        return tourGuideService.getNearByAttractionsInfo(user, attractions);
     }
     
     @RequestMapping("/getRewards") 

--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/dto/NearbyAttractionDto.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/dto/NearbyAttractionDto.java
@@ -1,0 +1,9 @@
+package com.openclassrooms.tourguide.dto;
+
+import gpsUtil.location.Location;
+
+public record NearbyAttractionDto(String attractionName,
+                                  Location attractionLocation,
+                                  Location userLocation,
+                                  double distance,
+                                  int rewardPoints) {}

--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/helper/Constants.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/helper/Constants.java
@@ -1,0 +1,5 @@
+package com.openclassrooms.tourguide.helper;
+
+public class Constants {
+    public final static int NB_OF_NEARBY_ATTRACTIONS = 5;
+}

--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -62,7 +62,7 @@ public class RewardsService {
 		return getDistance(attraction, visitedLocation.location) > proximityBuffer ? false : true;
 	}
 	
-	private int getRewardPoints(Attraction attraction, User user) {
+	protected int getRewardPoints(Attraction attraction, User user) {
 		return rewardsCentral.getAttractionRewardPoints(attraction.attractionId, user.getUserId());
 	}
 	

--- a/TourGuide/src/test/java/com/openclassrooms/tourguide/TestTourGuideService.java
+++ b/TourGuide/src/test/java/com/openclassrooms/tourguide/TestTourGuideService.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.jupiter.api.Disabled;
+import com.openclassrooms.tourguide.helper.Constants;
 import org.junit.jupiter.api.Test;
 
 import gpsUtil.GpsUtil;
@@ -92,7 +92,6 @@ public class TestTourGuideService {
 		assertEquals(user.getUserId(), visitedLocation.userId);
 	}
 
-	@Disabled // Not yet implemented
 	@Test
 	public void getNearbyAttractions() {
 		GpsUtil gpsUtil = new GpsUtil();


### PR DESCRIPTION
# Implémentation de la récupération des 5 attractions les plus proches

## Description
Cette PR introduit la fonctionnalité de récupération des **5 attractions les plus proches** de l'utilisateur.

---

## Principales modifications

### Services

#### `TourGuideService`
- **Modification** de la méthode `getNearbyAttractions()` pour récupérer les 5 premières attractions ordonnées par distance croissante de l'utilisateur.  
- **Création** de la méthode `getNearByAttractionsInfo(User, List<Attraction>)` qui retourne une liste de DTO créés à partir des attractions.  
  Chaque DTO comprend :
  - le nom de l'attraction,
  - la localisation de l'attraction,
  - la localisation de l'utilisateur,
  - la distance entre l'attraction et l'utilisateur,
  - le nombre de points de récompense que l'utilisateur peut gagner en visitant l'attraction.

#### `RewardsService`
- **Changement de visibilité** de la méthode `getRewardPoints()` : de `private` à `protected` pour permettre son accès par la classe `TourGuideService`.

---

### Contrôleur

#### `getNearbyAttractions()`
- Stockage du retour de `getUser()` dans une variable pour réutilisation lors de la récupération de la localisation de l'utilisateur et de la création des DTO.
- Appel à la nouvelle méthode `getNearByAttractionsInfo()` pour construire et retourner une liste de `NearbyAttractionDto`.

---

## Test
L'implémentation de la fonctionnalité est réalisée et le test `TestTourGuideService.getNearbyAttractions()` passe.

<img width="1103" height="209" alt="TestTourGuideService-OK" src="https://github.com/user-attachments/assets/e070ac1f-1804-4e6e-9d54-fd9a034459d5" />



