### PR TITLE
feat(optimization): use cached thread pool for async rewards calculation

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -3,6 +3,8 @@ package com.openclassrooms.tourguide.service;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.springframework.stereotype.Service;
 
@@ -24,8 +26,10 @@ public class RewardsService {
 	private int attractionProximityRange = 200;
 	private final GpsUtil gpsUtil;
 	private final RewardCentral rewardsCentral;
-	
-	public RewardsService(GpsUtil gpsUtil, RewardCentral rewardCentral) {
+
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    public RewardsService(GpsUtil gpsUtil, RewardCentral rewardCentral) {
 		this.gpsUtil = gpsUtil;
 		this.rewardsCentral = rewardCentral;
 	}
@@ -54,7 +58,7 @@ public class RewardsService {
                     }
                 }
             }
-        });
+        }, executorService);
     }
 	
 	public boolean isWithinAttractionProximity(Attraction attraction, Location location) {


### PR DESCRIPTION
# Optimisation des performances de calcul des récompenses

## Description
Cette PR **introduit l'utilisation d'un pool de thread à taille dynamique** dans RewardsService afin d'optimiser le traitement d'un grand volume d'utilisateurs dans la méthode asynchrone  `calculateRewards()` . 

---

## Principales modifications
### `RewardsService.calculateRewards()`
Instanciation d'un ExecutorService au niveau de la classe, avec `Executors.newCachedThreadPool()`. Ce type de pool crée autant de threads que nécessaire et réutilise ceux qui sont disponibles, ce qui permet une meilleure adaptation à la charge. 

La méthode `CompletableFuture.runAsync()` utilisée pour encapsuler la logique de calcul des récompenses, reçoit désormais en argument l'instance de ExecutorService définie dans la classe. 
ExecutorService remplace ainsi le ForkJoinPool utilisé par défaut, et qui est prévu pour un nombre fixe de thread.

---

### Tests
 - Tous les tests passent après refactorisation. 
 - La **performance** a été **améliorée**, le test de charge avec 100 000 utilisateurs  simulés s'exécute en 101 secondes (voir #5 ).

L'objectif d'exécution en moins de 20 minutes est atteint pour la méthode `TestPerformance.highVolumeGetRewards()`. 
  
---

### Améliorations futures
Ajuster la configuration du pool de thread selon les profils de charge.
