### PR TITLE
Feat/calculaterewards optimization

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/AttractionsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/AttractionsService.java
@@ -1,0 +1,16 @@
+package com.openclassrooms.tourguide.service;
+
+import gpsUtil.GpsUtil;
+import gpsUtil.location.Attraction;
+
+import java.util.List;
+
+public class AttractionsService extends GpsUtil {
+    private final static GpsUtil gpsUtil = new GpsUtil();
+
+    /**
+     * Immutable cached list of attractions, loaded once at application startup.
+     * This list wraps the result of a single call to {@link GpsUtil#getAttractions()}
+     */
+    public final static List<Attraction> allAttractions = List.copyOf(gpsUtil.getAttractions());
+}

--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -27,6 +27,8 @@ public class RewardsService {
 	private final GpsUtil gpsUtil;
 	private final RewardCentral rewardsCentral;
 
+    private final List<Attraction> allAttractions = AttractionsService.allAttractions;
+
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     public RewardsService(GpsUtil gpsUtil, RewardCentral rewardCentral) {
@@ -46,7 +48,6 @@ public class RewardsService {
         return CompletableFuture.runAsync(() -> {
             synchronized (user) {
                 List<VisitedLocation> userLocations = new CopyOnWriteArrayList<>(user.getVisitedLocations());
-                List<Attraction> attractions = gpsUtil.getAttractions();
 
                 for (VisitedLocation visitedLocation : userLocations) {
                     for (Attraction attraction : attractions) {
@@ -54,6 +55,7 @@ public class RewardsService {
                             if (nearAttraction(visitedLocation, attraction)) {
                                 user.addUserReward(new UserReward(visitedLocation, attraction, getRewardPoints(attraction, user)));
                             }
+                    for (Attraction attraction : allAttractions) {
                         }
                     }
                 }

--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/TourGuideService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/TourGuideService.java
@@ -40,6 +40,7 @@ public class TourGuideService {
 	private final TripPricer tripPricer = new TripPricer();
 	public final Tracker tracker;
 	boolean testMode = true;
+	private final List<Attraction> allAttractions = AttractionsService.allAttractions;
 
 	public TourGuideService(GpsUtil gpsUtil, RewardsService rewardsService) {
 		this.gpsUtil = gpsUtil;
@@ -108,9 +109,7 @@ public class TourGuideService {
 	 * @return a list of the nearest {@link Attraction}
 	 */
 	public List<Attraction> getNearByAttractions(VisitedLocation visitedLocation) {
-		List<Attraction> attractions = gpsUtil.getAttractions();
-
-		return attractions.stream()
+		return allAttractions.stream()
 				.sorted(Comparator.comparingDouble(attraction ->
 						rewardsService.getDistance(visitedLocation.location,
 													new Location(attraction.latitude, attraction.longitude))))

--- a/TourGuide/src/test/java/com/openclassrooms/tourguide/TestPerformance.java
+++ b/TourGuide/src/test/java/com/openclassrooms/tourguide/TestPerformance.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import com.openclassrooms.tourguide.service.AttractionsService;
 import org.apache.commons.lang3.time.StopWatch;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +22,7 @@ import com.openclassrooms.tourguide.service.TourGuideService;
 import com.openclassrooms.tourguide.user.User;
 
 public class TestPerformance {
+	private final List<Attraction> allAttractions = AttractionsService.allAttractions;
 
 	/*
 	 * A note on performance improvements:
@@ -82,7 +84,7 @@ public class TestPerformance {
 		stopWatch.start();
 		TourGuideService tourGuideService = new TourGuideService(gpsUtil, rewardsService);
 
-		Attraction attraction = gpsUtil.getAttractions().get(0);
+		Attraction attraction = allAttractions.get(0);
 		List<User> allUsers = new ArrayList<>();
 		allUsers = tourGuideService.getAllUsers();
 		allUsers.forEach(u -> u.addToVisitedLocations(new VisitedLocation(u.getUserId(), attraction, new Date())));

--- a/TourGuide/src/test/java/com/openclassrooms/tourguide/TestRewardsService.java
+++ b/TourGuide/src/test/java/com/openclassrooms/tourguide/TestRewardsService.java
@@ -7,7 +7,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.jupiter.api.Disabled;
+import com.openclassrooms.tourguide.service.AttractionsService;
 import org.junit.jupiter.api.Test;
 
 import gpsUtil.GpsUtil;
@@ -22,6 +22,8 @@ import com.openclassrooms.tourguide.user.UserReward;
 
 public class TestRewardsService {
 
+	private final List<Attraction> allAttractions = AttractionsService.allAttractions;
+
 	@Test
 	public void userGetRewards() {
 		GpsUtil gpsUtil = new GpsUtil();
@@ -31,7 +33,7 @@ public class TestRewardsService {
 		TourGuideService tourGuideService = new TourGuideService(gpsUtil, rewardsService);
 
 		User user = new User(UUID.randomUUID(), "jon", "000", "jon@tourGuide.com");
-		Attraction attraction = gpsUtil.getAttractions().get(0);
+		Attraction attraction = allAttractions.get(0);
 		user.addToVisitedLocations(new VisitedLocation(user.getUserId(), attraction, new Date()));
 		tourGuideService.trackUserLocation(user);
 		List<UserReward> userRewards = user.getUserRewards();
@@ -43,7 +45,7 @@ public class TestRewardsService {
 	public void isWithinAttractionProximity() {
 		GpsUtil gpsUtil = new GpsUtil();
 		RewardsService rewardsService = new RewardsService(gpsUtil, new RewardCentral());
-		Attraction attraction = gpsUtil.getAttractions().get(0);
+		Attraction attraction = allAttractions.get(0);
 		assertTrue(rewardsService.isWithinAttractionProximity(attraction, attraction));
 	}
 
@@ -60,6 +62,6 @@ public class TestRewardsService {
 		List<UserReward> userRewards = tourGuideService.getUserRewards(tourGuideService.getAllUsers().get(0));
 		tourGuideService.tracker.stopTracking();
 
-		assertEquals(gpsUtil.getAttractions().size(), userRewards.size());
+		assertEquals(allAttractions.size(), userRewards.size());
 	}
 }


### PR DESCRIPTION
# Optimisation des méthode de récupération des récompenses

## Description
Cette PR optimise encore les performances des méthodes qui calculent les récompenses utilisateurs. 

---

## Principales modifications
### AttractionsService
Création d'un **service chargé d'instancier la dépendance GpsUtil**, d'appeler sa méthode `getAttractions()` et de **stocker le retour dans une variable final static `allAttractions`**. 

### Utilisation de la variable static
Les services et tests qui appelaient la méthode GpsUtil#getAttractions() **utilisent désormais une référence** à `AttractionsService#allAttractions`. 

--- 

## Tests

### Tests de charge pour 100 000 utilisateurs
#### avec appel répétitif à méthode `GpsUtil#getAttractions()` : 

<img width="1094" height="521" alt="calculateRewards-100000users-with-repeated-gpsUtil-calls" src="https://github.com/user-attachments/assets/b9381203-256a-40cd-9979-85ee237889a2" />


#### avec une variable static

<img width="1087" height="595" alt="calculateRewards-100000users-with-static-variable" src="https://github.com/user-attachments/assets/decfc299-8c9c-4e63-8e1e-f80e5bbca993" />

---

En réduisant la dépendance directe à la librairie GpsUtil grâce à une **liste d'attractions instanciée au lancement de l'application**, on évite des appels répétés à `getAttractions()`. 
Les performances sont drastiquement améliorée. Le test de charge `highVolumeGetRewards()` est **exécuté en 4 secondes, contre 400 secondes avant refactorisation**. 

