### PR TITLE
use cached attractions list + clean code

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -50,12 +50,11 @@ public class RewardsService {
                 List<VisitedLocation> userLocations = new CopyOnWriteArrayList<>(user.getVisitedLocations());
 
                 for (VisitedLocation visitedLocation : userLocations) {
-                    for (Attraction attraction : attractions) {
+                    for (Attraction attraction : allAttractions) {
                         if (user.getUserRewards().stream().noneMatch(r -> r.attraction.attractionName.equals(attraction.attractionName))) {
                             if (nearAttraction(visitedLocation, attraction)) {
                                 user.addUserReward(new UserReward(visitedLocation, attraction, getRewardPoints(attraction, user)));
                             }
-                    for (Attraction attraction : allAttractions) {
                         }
                     }
                 }


### PR DESCRIPTION
Use a final variable referencing the memoized list of attractions instead of calling `GpsUtil#getAttractions()` directly. 
Clean code. 