### PR TITLE
Chore/ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,3 +51,4 @@ package-job: # package the project
   artifacts:
     paths:
       - TourGuide/target/*.jar
+    name: "tourguide-jar-artifacts"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,6 @@ build-job: # check the local maven repository contains installed JARs and compil
   stage: build
   script:
     - cd TourGuide
-    - ls -lR $CI_PROJECT_DIR/.m2/repository
     - mvn clean compile
 
 test-job: # execute tests
@@ -41,7 +40,7 @@ package-job: # package the project
   script:
     - cd TourGuide
     - |
-      ./mvnw package \
+      ./mvnw clean package \
       -Dhttps.protocols=TLSv1.2 \
       -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
 stages:          # List of stages for jobs, and their order of execution
   - prepare
   - build
+  - test
   - package
 
 cache:            # jobs that use the same cache don’t have to download the files again
@@ -29,6 +30,12 @@ build-job: # check the local maven repository contains installed JARs and compil
     - ls -lR $CI_PROJECT_DIR/.m2/repository
     - mvn clean compile
 
+test-job: # execute tests
+  stage: test
+  script:
+    - cd TourGuide
+    - mvn clean test
+
 package-job: # package the project
   stage: package
   script:
@@ -41,3 +48,6 @@ package-job: # package the project
       -Dorg.slf4j.simpleLogger.showDateTime=true \
       -Djava.awt.headless=true \
       --batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true
+  artifacts:
+    paths:
+      - TourGuide/target/*.jar


### PR DESCRIPTION
# Finalisation du pipeline d'intégration continue

## Description
Cette PR affine le pipeline d'intégration continue en ajoutant le JAR généré par le packaging du projet à l'archive téléchargeable depuis GitLab, et en nettoyant les fichiers de build issus des précédents jobs.

### Principales modifications
#### `package-job`
Ajout de la section `artifacts` pointant vers le répertoire `target` du projet TourGuide, avec une propriété `name` pour faciliter l'identification de l’archive téléchargée.

---

<img width="1265" height="174" alt="image" src="https://github.com/user-attachments/assets/03114d59-7ad1-487b-b8b3-4e180d8e7ef2" />

<img width="870" height="122" alt="image" src="https://github.com/user-attachments/assets/7e39b117-242e-4574-8fb3-788882dcd47d" />
