### PR TITLE
chore(optimization): switch to FixedThreadPool to improve stability

### DIFF
--- a/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
+++ b/TourGuide/src/main/java/com/openclassrooms/tourguide/service/RewardsService.java
@@ -29,7 +29,7 @@ public class RewardsService {
 
     private final List<Attraction> allAttractions = AttractionsService.allAttractions;
 
-    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(500);
 
     public RewardsService(GpsUtil gpsUtil, RewardCentral rewardCentral) {
 		this.gpsUtil = gpsUtil;


### PR DESCRIPTION
# Correction de la stratégie de création des threads

## Contexte 
L’implémentation précédente utilisait Executors.newCachedThreadPool().
Cette approche crée dynamiquement un nombre potentiellement très élevé de threads.
Lors d’un test de charge massif (100 000 utilisateurs), cela peut entraîner une surconsommation mémoire, voire un risque d’épuisement des ressources serveur.

## Description
Cette PR modifie la stratégie de création des threads afin de plafonner leur nombre. 
En effet, un grand nombre de threads peut être créé dynamiquement lors du test de charge, ce qui peut épuiser les ressources mémoire du serveur. 

## Principales modifications
### RewardsService
Dans l'instanciation de l'Executor Service, appel à la méthode newFixedThreadPool(500) pour plafonner le nombre de threads. 

Le plafond de 500 threads permet de contrôler la consommation mémoire, d’éviter la création excessive de threads, et de maintenir un bon niveau de parallélisme lors du traitement concurrent des utilisateurs.

--- 


## Tests
Tests de charge pour 100 000 utilisateurs : exécuté en 101 secondes. 

<img width="1404" height="575" alt="calculateRewards-500-threads" src="https://github.com/user-attachments/assets/f6881e62-4739-4ca8-808a-511c162f4ec9" />

## Modifications à venir

L'application de la formule de Brian Goetz pour le calcul du nombre de threads à utiliser indique toutefois une recommandation de plus de 10000 threads pour traiter les appels massifs à calculateRewards(). 
 Le coût en mémoire serait trop élevé pour envisager cette configuration. 
Les threads virtuels permettraient d'optimiser les performances sans causer d'instabilité ni épuiser la mémoire.

