### PR TITLE
feat(it): add integration test for /getNearbyAttractions endpoint

### DIFF
--- a/TourGuide/src/test/java/com/openclassrooms/tourguide/IT/TestTourGuideController.java
+++ b/TourGuide/src/test/java/com/openclassrooms/tourguide/IT/TestTourGuideController.java
@@ -1,0 +1,28 @@
+package com.openclassrooms.tourguide.IT;
+
+import com.openclassrooms.tourguide.service.TourGuideService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class TestTourGuideController {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TourGuideService service;
+
+    @Test
+    void testGetNearbyAttractionsInfo_shouldReturnDto() throws Exception {
+        String username = service.getAllUsers().get(0).getUserName();
+        mockMvc.perform(get("/getNearbyAttractions?userName="+username))
+                .andExpect(jsonPath("$").isArray());
+    }
+}


### PR DESCRIPTION
# Tests d'intégration

## Description 
Cette PR introduit les premières bases pour les tests d'intégration du contrôleur avec les services 

## Principales modifications
### package `it` : TestTourGuideController
Création d'une classe de test avec `@AutoConfigureMockMvc`.
Ajout d'un premier test de l'endpoint "/getNearbyAttractions". 
Vérification du type de données retournées par le contrôleur. 

---

Ce premier test permet de s'assurer que le contrôleur est correctement exposé et que la réponse à cette requête respecte le format attendu. 

## Prochaine étape
Enrichissement des tests pour garantir une couverture de tous les endpoints. 
 